### PR TITLE
:recycle: refactor: Garantindo que o layout não quebre

### DIFF
--- a/src/components/ListarNotificacoes.jsx
+++ b/src/components/ListarNotificacoes.jsx
@@ -631,13 +631,18 @@ const ListarNotificacoes = () => {
                         <div className="d-flex align-items-center">
 
                         <FaClipboardList />‎
-                        {window.innerWidth <= 400 ? (
-                          <small className="ms-1 d-inline-block text-truncate" style={{ maxWidth: '170px' }}>
+                        
+                        {window.innerWidth <= 310 ? (
+                          <small className="ms-1 d-inline-block text-truncate" style={{ maxWidth: '160px' }}>
                             Motivo: {link.tipo_notificacao}
-                          </small>                        ) : (
+                          </small>
+                        ) : window.innerWidth <= 400 ? (
+                          <small className="ms-1 d-inline-block text-truncate" style={{ maxWidth: '200px' }}>
+                            Motivo: {link.tipo_notificacao}
+                          </small>
+                        ) : (
                           `Motivo: ${link.tipo_notificacao}`
-
-                        )} </div>
+                        )}</div>
                       </h6>
                     
                   </div>

--- a/src/components/ListarNotificacoes.jsx
+++ b/src/components/ListarNotificacoes.jsx
@@ -37,7 +37,8 @@ const ListarNotificacoes = () => {
   const [filtroAtual, setFiltroAtual] = useState("");
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+
   const atualiza = (index) => {
     data[index].estado = !data[index].estado;
     setData([...data]);
@@ -396,12 +397,15 @@ const ListarNotificacoes = () => {
       });
   }
 
-      const quebrarTexto = (texto, comprimentoMaximo) => {
-      if (texto.length > comprimentoMaximo) {
-        return texto.substring(0, comprimentoMaximo) + '...';
-      }
-      return texto;
-    };  
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <>
@@ -627,10 +631,12 @@ const ListarNotificacoes = () => {
                         <div className="d-flex align-items-center">
 
                         <FaClipboardList />‎
-                        {window.innerWidth <= 360 ? (
-                          <small className="ms-1">Motivo: {quebrarTexto(link.tipo_notificacao, 15)}</small>
-                        ) : (
-                          `Motivo: ${quebrarTexto(link.tipo_notificacao, 40)}`
+                        {window.innerWidth <= 400 ? (
+                          <small className="ms-1 d-inline-block text-truncate" style={{ maxWidth: '170px' }}>
+                            Motivo: {link.tipo_notificacao}
+                          </small>                        ) : (
+                          `Motivo: ${link.tipo_notificacao}`
+
                         )} </div>
                       </h6>
                     

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 code {


### PR DESCRIPTION
Garantindo que apareça os ... para diminuir o texto e impedir que o layout quebre, e adicionando propriedades CSS que impeçam que as configurações alterem padrões de tamanho de texto

Ajustado:
![image](https://github.com/user-attachments/assets/6d1b643e-44bd-43d9-a52f-9356e71e2ac0)