### PR TITLE
:recycle: refactor: Ajuste no componente Filtro para permitir filtragem apenas por Data e Período nos Relatórios Financeiros

### DIFF
--- a/src/util/Filtro.jsx
+++ b/src/util/Filtro.jsx
@@ -208,8 +208,6 @@ const Filtro = ({ nome, onConsultaSelected, onLoading }) => {
       setOptions([
         { value: "Data", label: "Data" },
         { value: "Periodo", label: "Período" },
-        { value: "DataHora", label: "Data e hora" },
-        { value: "PeriodoHora", label: "Período e hora" },
       ]);
     } else if (nome === "ClientesAdmin") {
       setOptions([


### PR DESCRIPTION
Este PR altera o comportamento do componente Filtro.jsx para que as opções de filtragem "Data" e "Período" considerem apenas a data (ou intervalo de datas), removendo a possibilidade de filtrar por data e hora ou período e hora.