### PR TITLE
:recycle: refactor: Nome adicionado na listagem de veiculos

### DIFF
--- a/src/components/BuscarVeiculo.jsx
+++ b/src/components/BuscarVeiculo.jsx
@@ -146,6 +146,7 @@ const BuscarVeiculo = () => {
             debito: item.debitar_automatico === "S" ? "Ativo" : "Inativo",
             saldo: item.saldo,
             cpf: item.cpf,
+            nome: item.nome,
             estacionado: item.estacionado[0].estacionado,
             tempo: item.estacionado[0].tempo,
             chegada: item.estacionado[0].chegada,
@@ -416,6 +417,14 @@ const BuscarVeiculo = () => {
                             >
                               <h6>
                                 <BsCashCoin  />‎ Saldo: {link.saldo}
+                              </h6>                            
+                            
+                            </div>  
+                             <div
+                              className="h6 d-flex align-items-center fs-6"
+                              id="estacionadocarroo"
+                            ><h6>
+                              <BsCardList />‎ Nome: {link.nome}
                               </h6>
                             </div>
                             {user2 ? user2.perfil[0] === "admin" ? (

--- a/src/components/BuscarVeiculo.jsx
+++ b/src/components/BuscarVeiculo.jsx
@@ -410,7 +410,13 @@ const BuscarVeiculo = () => {
                           </div>
 
                           {link.debito === "Ativo" ? (
-                            <>
+                            <>                             <div
+                              className="h6 d-flex align-items-center fs-6"
+                              id="estacionadocarroo"
+                            ><h6>
+                              <BsCardList />‎ Debitando de: {link.nome}
+                              </h6>
+                            </div>
                             <div
                               className="h6 d-flex align-items-center fs-6"
                               id="estacionadocarroo"
@@ -420,13 +426,7 @@ const BuscarVeiculo = () => {
                               </h6>                            
                             
                             </div>  
-                             <div
-                              className="h6 d-flex align-items-center fs-6"
-                              id="estacionadocarroo"
-                            ><h6>
-                              <BsCardList />‎ Nome: {link.nome}
-                              </h6>
-                            </div>
+
                             {user2 ? user2.perfil[0] === "admin" ? (
                             <div
                             className="h6 d-flex align-items-center fs-6"


### PR DESCRIPTION
Adição do nome do usuário com débito ativo na listagem do veículo

Foi adicionado à listagem do veículo o nome do usuário que possui o débito automático ativo.

Identifiquei algumas situações em que clientes reclamam com as monitoras por terem recebido notificação, mesmo com o débito automático ativado e saldo disponível. Ao verificarem, as monitoras percebem que o débito realmente está ativo, mas o saldo exibido não pertence ao cliente que está reclamando — pois o débito automático está vinculado a outro usuário.

Como anteriormente a listagem mostrava apenas que o débito estava ativo e o saldo disponível, sem indicar a quem pertenciam essas informações, acabavam ocorrendo confusões. Por isso, adicionei o nome do cliente vinculado ao débito automático. Assim, quando esses casos acontecerem, a própria monitora poderá identificar de imediato o titular do débito e informar ao reclamante que ele pertence a outra pessoa.

![image](https://github.com/user-attachments/assets/1f5202f0-d03f-41d4-8bc6-a95aed31ace9)
